### PR TITLE
Add gost-engine provider overlay

### DIFF
--- a/src/openvpn/contrib/vcpkg-manifests/windows/vcpkg.json
+++ b/src/openvpn/contrib/vcpkg-manifests/windows/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "name": "openvpn",
+  "version": "2.7",
+  "dependencies": [
+      {
+        "name": "openssl",
+        "features": ["tools"]
+      },
+      "gost-engine",
+      "tap-windows6",
+      "lzo",
+      "lz4",
+      "pkcs11-helper",
+      "cmocka",
+      {
+          "name": "pkgconf",
+          "host": true
+      }
+  ]
+}

--- a/windows-msi/vcpkg-ports/gost-engine/portfile.cmake
+++ b/windows-msi/vcpkg-ports/gost-engine/portfile.cmake
@@ -1,0 +1,32 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gost-engine/engine
+    REF 806d9ee6f1075f715b6ce6e32fc2b3e88763448b
+    SHA512 138b6cef10d1c59b086f4f6dbd86e3a78b2e266a1635a552e8351bd7570da8bcb37791b07fa430457243a65f3b26b05d5b8d8ac8ec8547c90eb97cdb153d14f0
+    HEAD_REF master
+)
+
+vcpkg_execute_required_process(
+    COMMAND git submodule update --init
+    WORKING_DIRECTORY ${SOURCE_PATH}
+    LOGNAME update-submodules
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DOPENSSL_ROOT_DIR=${CURRENT_INSTALLED_DIR}
+        -DOPENSSL_ENGINES_DIR=${CURRENT_PACKAGES_DIR}/lib/engines-3
+        -DOPENSSL_MODULES_DIR=${CURRENT_PACKAGES_DIR}/lib/ossl-modules
+)
+
+vcpkg_cmake_install()
+
+file(GLOB PROVIDER_DLL
+    "${CURRENT_PACKAGES_DIR}/lib/ossl-modules/*gost*.dll"
+    "${CURRENT_PACKAGES_DIR}/lib/ossl-modules/*gost*.so"
+    "${CURRENT_PACKAGES_DIR}/lib/ossl-modules/*gost*.dylib"
+)
+if(PROVIDER_DLL)
+    file(INSTALL DESTINATION "${CURRENT_PACKAGES_DIR}/lib/ossl-modules" TYPE FILE FILES ${PROVIDER_DLL})
+endif()

--- a/windows-msi/vcpkg-ports/gost-engine/vcpkg.json
+++ b/windows-msi/vcpkg-ports/gost-engine/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "gost-engine",
+  "version-date": "2025-05-28",
+  "description": "GOST provider and engine for OpenSSL",
+  "homepage": "https://github.com/gost-engine/engine",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    "openssl"
+  ]
+}


### PR DESCRIPTION
## Summary
- add new overlay port `gost-engine` for the OpenSSL GOST provider
- include gost-engine in the Windows vcpkg manifest so it builds alongside OpenSSL

## Testing
- `git clone --depth 1 https://github.com/gost-engine/engine.git /tmp/engine-test`
- `git -C /tmp/engine-test submodule update --init`
- `cmake -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=/tmp/openssl ..`
- `cmake --build . --config Release`
- `cmake --install . --config Release --prefix /tmp/engine-install`

------
https://chatgpt.com/codex/tasks/task_e_686d21119ab0832e985a0e83dd221363