### PR TITLE
[gost-engine] add OpenSSL GOST engine port

### DIFF
--- a/ports/gost-engine/portfile.cmake
+++ b/ports/gost-engine/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gost-engine/engine
+    REF v3.0.3
+    SHA512 3a66e95b743475f36372b51de852caa442ff423110668e7ba082f93f7c7d151a5d19db7f3ddbd4dae4af4578cdf0e50c099b71dcc6d7e8f049cbfb3fb28f567a
+    SUBMODULES libprov
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS -DOPENSSL_ROOT_DIR=${CURRENT_INSTALLED_DIR}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/gost-engine/usage
+++ b/ports/gost-engine/usage
@@ -1,0 +1,2 @@
+The gost-engine port provides the OpenSSL GOST engine and provider modules.
+Refer to upstream documentation for enabling the engine in OpenSSL.

--- a/ports/gost-engine/vcpkg.json
+++ b/ports/gost-engine/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "gost-engine",
+  "version": "3.0.3",
+  "description": "A reference implementation of the Russian GOST crypto algorithms for OpenSSL",
+  "homepage": "https://github.com/gost-engine/engine",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "openssl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3356,6 +3356,10 @@
       "baseline": "alias",
       "port-version": 2
     },
+    "gost-engine": {
+      "baseline": "3.0.3",
+      "port-version": 0
+    },
     "gperf": {
       "baseline": "3.1",
       "port-version": 7

--- a/versions/g-/gost-engine.json
+++ b/versions/g-/gost-engine.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a0234dadd124b4b276c58401709bee08741ae0d9",
+      "version": "3.0.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add gost-engine port with libprov submodule and OpenSSL dependency
- register gost-engine in versioning baseline

## Testing
- `./vcpkg format-manifest ports/gost-engine/vcpkg.json`
- `./vcpkg x-add-version gost-engine --overwrite-version`


------
https://chatgpt.com/codex/tasks/task_e_6890d53d301c832e9bf91d8a56a344eb